### PR TITLE
init-ostree.sh: move /run over to the new rootfs

### DIFF
--- a/recipes-sota/initrdscripts/files/init-ostree.sh
+++ b/recipes-sota/initrdscripts/files/init-ostree.sh
@@ -327,12 +327,14 @@ fi
 
 rm_var_check
 
+# stop udev daemon
 udevadm control -e
 
-cd $ROOT_MOUNT
-for x in dev proc sys; do
-	log_info "Moving /$x to new rootfs"
-	mount --move "/$x" "$x"
+# move virtual filesystems to new root (not automatically done by
+# busybox's switch_root)
+for vfs in dev proc sys run; do
+    log_info "Moving /$vfs to new rootfs"
+    mount --move /${vfs} ${ROOT_MOUNT}/${vfs}
 done
 
 # !!! The Big Fat Warnings !!!


### PR DESCRIPTION
/run was missing. This was causing boot failures on systems built using
the feature/encrypted-storage flag.

The udev database is stored in /run/udev/data. This database can be
repopulated in part but not entirely. It is especially important in
the case of the 10-dm.rules udev rules. Excerpt:

    If udev is used in initrd, we require the udev init script to not
    remove the existing udev database so we can reuse the information
    stored at the time of device activation in the initrd.

By moving the content of /run the boot process now completes without
errors.

Signed-off-by: Marc Ferland <ferlandm@amotus.ca>